### PR TITLE
Update a-better-way-to-learn-swift.mdown

### DIFF
--- a/a-better-way-to-learn-swift.mdown
+++ b/a-better-way-to-learn-swift.mdown
@@ -337,7 +337,7 @@ basics, but these readings will give you a more complete understanding.
 Read [the Functions chapter][chapter_functions] in the Swift ebook.
 
 {x: chapter_closures}
-Read [the Optionals chapter][chapter_closures] in the Swift ebook.
+Read [the Closures chapter][chapter_closures] in the Swift ebook.
 
 {x: basic_functions_closures}
 Read [A Basic Tutorial on Functions and Closures in Swift][basic_functions_closures] for clarification on functions, closures, and closure expressions.


### PR DESCRIPTION
Line 340 should read "Read the Closures chapter in the Swift ebook.", not "Read the Optionals chapter in the Swift ebook"
